### PR TITLE
cleanup code to remove race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+    - 1.4.2
+    - 1.5.1
+    
+install: make go-deps
+
+script: go test ./udt -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
     - 1.4.2
     - 1.5.1
-    
+
 install: make go-deps
 
-script: go test ./udt -v
+script: cd udt && go test -v

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+go-deps: 
+	cd udt4/src && make libudt.a
+	cp udt4/src/libudt.a udt/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
-go-deps: 
+go-deps:
 	cd udt4/src && make libudt.a
 	cp udt4/src/libudt.a udt/
+	cd udt && go get ./...

--- a/udt/fd.go
+++ b/udt/fd.go
@@ -4,12 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
 	"syscall"
 	"time"
 	"unsafe"
-
-	ctxgrp "github.com/jbenet/go-ctxgroup"
 )
 
 // #cgo CFLAGS: -Wall
@@ -59,21 +56,15 @@ type semaphore chan struct{}
 
 // udtFD (wraps udt.socket)
 type udtFD struct {
-	csema semaphore
-	rsema semaphore
-	wsema semaphore
-	proc  ctxgrp.ContextGroup
-
 	refcnt int32
 	bound  bool
 
 	// immutable until Close
-	sock        C.UDTSOCKET
-	localClose  bool
-	isConnected bool
-	net         string
-	laddr       *UDTAddr
-	raddr       *UDTAddr
+	sock C.UDTSOCKET
+
+	net   string
+	laddr *UDTAddr
+	raddr *UDTAddr
 }
 
 func newFD(sock C.UDTSOCKET, laddr, raddr *UDTAddr, net string) (*udtFD, error) {
@@ -81,39 +72,7 @@ func newFD(sock C.UDTSOCKET, laddr, raddr *UDTAddr, net string) (*udtFD, error) 
 	rac := raddr.copy()
 	fd := &udtFD{sock: sock, laddr: lac, raddr: rac, net: net}
 
-	// sync managing.
-	fd.csema = make(semaphore, 1)
-	fd.rsema = make(semaphore, 1)
-	fd.wsema = make(semaphore, 1)
-	fd.csema <- signal{}
-	fd.rsema <- signal{}
-	fd.wsema <- signal{}
-	fd.proc = ctxgrp.WithTeardown(fd.teardown)
-	fd.proc.AddChildFunc(fd.connectionCheck)
-	runtime.SetFinalizer(fd, (*udtFD).Close)
 	return fd, nil
-}
-
-func (fd *udtFD) connectionCheck(ctxgrp.ContextGroup) {
-
-	for {
-		select {
-		case <-fd.proc.Closing():
-			<-time.After(500 * time.Millisecond) // wait for flushing to happen (TODO)
-			<-fd.csema                           // take it forever.
-			go closeSocket(fd.sock)
-			return
-
-		// check for connection death
-		case <-time.After(time.Duration(UDT_ASYNC_TIMEOUT) * time.Millisecond):
-			if getSocketStatus(fd.sock).inTeardown() {
-				<-time.After(500 * time.Millisecond) // wait for flushing to happen (TODO)
-				<-fd.csema                           // take it forever.
-				go fd.Close()
-				return
-			}
-		}
-	}
 }
 
 // lastErrorOp returns the last error as a net.OpError.
@@ -159,34 +118,6 @@ func (fd *udtFD) setDefaultOpts() error {
 	return nil
 }
 
-func (fd *udtFD) setAsyncOpts() error {
-
-	if C.udt_setsockopt(fd.sock, 0, C.UDT_RCVTIMEO, unsafe.Pointer(&UDT_RCVTIMEO_MS), C.sizeof_int) != 0 {
-		return fmt.Errorf("failed to set UDT_RCVTIMEO: %s", lastError())
-	}
-
-	if C.udt_setsockopt(fd.sock, 0, C.UDT_SNDTIMEO, unsafe.Pointer(&UDT_SNDTIMEO_MS), C.sizeof_int) != 0 {
-		return fmt.Errorf("failed to set UDT_SNDTIMEO: %s", lastError())
-	}
-
-	// full async is off
-
-	// options
-	// falseint := C.int(0)
-
-	// // set sending to be async
-	// if C.udt_setsockopt(fd.sock, 0, C.UDT_SNDSYN, unsafe.Pointer(&falseint), C.sizeof_int) != 0 {
-	// 	return fmt.Errorf("failed to set UDT_SNDSYN: %s", lastError())
-	// }
-
-	// // set receiving to be async
-	// if C.udt_setsockopt(fd.sock, 0, C.UDT_RCVSYN, unsafe.Pointer(&falseint), C.sizeof_int) != 0 {
-	// 	return fmt.Errorf("failed to set UDT_RCVSYN: %s", lastError())
-	// }
-
-	return nil
-}
-
 func (fd *udtFD) bind() error {
 	_, sa, salen, err := fd.laddr.socketArgs()
 	if err != nil {
@@ -211,11 +142,6 @@ func (fd *udtFD) listen(backlog int) error {
 }
 
 func (fd *udtFD) accept() (*udtFD, error) {
-	if err := fd.incref(); err != nil {
-		return nil, err
-	}
-	defer fd.decref()
-
 	var sa syscall.RawSockaddrAny
 	var salen C.int
 
@@ -237,19 +163,10 @@ func (fd *udtFD) accept() (*udtFD, error) {
 		return nil, err
 	}
 
-	if err = remotefd.setAsyncOpts(); err != nil {
-		remotefd.Close()
-		return nil, err
-	}
-
 	return remotefd, nil
 }
 
 func (fd *udtFD) connect(raddr *UDTAddr) error {
-	if err := fd.incref(); err != nil {
-		return err
-	}
-	defer fd.decref()
 
 	_, sa, salen, err := raddr.socketArgs()
 	if err != nil {
@@ -277,17 +194,19 @@ func (fd *udtFD) connect(raddr *UDTAddr) error {
 
 		fd.laddr = laddr
 	}
-	return fd.setAsyncOpts()
+	return nil
 }
 
 func (fd *udtFD) Close() error {
-	return fd.proc.Close()
-}
-
-func (fd *udtFD) teardown() error {
-	closeSocket(fd.sock)
+	err := closeSocket(fd.sock)
 	fd.sock = -1
-	runtime.SetFinalizer(fd, nil)
+	if err != nil {
+		if err.Error() == "Operation not supported: Invalid socket ID." {
+			// this ones okay, just means its already closed, somewhere
+			return nil
+		}
+		return err
+	}
 	return nil
 }
 

--- a/udt/fd.go
+++ b/udt/fd.go
@@ -96,28 +96,6 @@ func (fd *udtFD) name() string {
 	return fd.net + ":" + ls + "->" + rs
 }
 
-func (fd *udtFD) setDefaultOpts() error {
-
-	// reduce maximum size
-	if C.udt_setsockopt(fd.sock, 0, C.UDP_RCVBUF, unsafe.Pointer(&UDP_RCVBUF_SIZE), C.sizeof_int) != 0 {
-		return fmt.Errorf("failed to set UDP_RCVBUF: %d, %s", UDP_RCVBUF_SIZE, lastError())
-	}
-
-	// set UDT_REUSEADDR
-	trueint := C.int(1)
-	if C.udt_setsockopt(fd.sock, 0, C.UDT_REUSEADDR, unsafe.Pointer(&trueint), C.sizeof_int) != 0 {
-		return fmt.Errorf("failed to set UDT_REUSEADDR: %s", lastError())
-	}
-
-	// unset UDT_LINGER
-	// falseint := C.int(0)
-	// if C.udt_setsockopt(fd.sock, 0, C.UDT_LINGER, unsafe.Pointer(&falseint), C.sizeof_int) != 0 {
-	// 	return fmt.Errorf("failed to set UDT_LINGER: %s", lastError())
-	// }
-
-	return nil
-}
-
 func (fd *udtFD) bind() error {
 	_, sa, salen, err := fd.laddr.socketArgs()
 	if err != nil {
@@ -276,11 +254,6 @@ func dialFD(laddr, raddr *UDTAddr) (*udtFD, error) {
 		return nil, err
 	}
 
-	if err := fd.setDefaultOpts(); err != nil {
-		fd.Close()
-		return nil, err
-	}
-
 	if laddr != nil {
 		if err := fd.bind(); err != nil {
 			fd.Close()
@@ -311,11 +284,6 @@ func listenFD(laddr *UDTAddr) (*udtFD, error) {
 	fd, err := newFD(sock, laddr, nil, "udt")
 	if err != nil {
 		closeSocket(sock)
-		return nil, err
-	}
-
-	if err := fd.setDefaultOpts(); err != nil {
-		fd.Close()
 		return nil, err
 	}
 

--- a/udt/fd_rw.go
+++ b/udt/fd_rw.go
@@ -1,8 +1,8 @@
 package udt
 
 import (
+	"fmt"
 	"io"
-	"net"
 	"unsafe"
 )
 
@@ -22,156 +22,52 @@ func slice2cbuf(buf []byte) *C.char {
 // udtIOError interprets the udt_getlasterror_code and returns an
 // error if IO systems should stop.
 func (fd *udtFD) udtIOError() error {
-	// switch C.udt_getlasterror_code() {
-	// case C.UDT_SUCCESS: // success :)
-	// case C.UDT_ECONNFAIL, C.UDT_ECONNLOST: // connection closed
-	// case C.UDT_EASYNCRCV, C.UDT_EASYNCSND: // no data to read (async)
-	// case C.UDT_ETIMEOUT: // timeout that we triggered
-	// default: // unexpected error, bail
-	//  return lastError()
-	// }
-
-	// timeout and/or closing.
-
-	// TODO remove this and turn async off. This timeout is here because I'm seeing
-	// unexpected blocking (violating the timeout). Its not clear how the UDT async
-	// stuff and Goroutines mesh... this worked.
-	// UPDATE: async disabled for now.
-	select {
-	// case <-time.After(time.Duration(UDT_ASYNC_TIMEOUT) * time.Millisecond):
-	case <-fd.proc.Closing():
-		return io.EOF // seems to have been a graceful close
-	default:
+	ec := C.udt_getlasterror_code()
+	switch ec {
+	case C.UDT_SUCCESS: // success :)
+	case C.UDT_ECONNFAIL, C.UDT_ECONNLOST: // connection closed
+		// TODO: maybe return some sort of error? this is weird
+	case C.UDT_EASYNCRCV, C.UDT_EASYNCSND: // no data to read (async)
+	case C.UDT_ETIMEOUT: // timeout that we triggered
+	case C.UDT_EINVSOCK:
+		// This one actually means that the socket was closed
+		return io.EOF
+	default: // unexpected error, bail
+		return lastError()
 	}
+
 	return nil
 }
 
-func (fd *udtFD) incref() error {
-	select {
-	case <-fd.proc.Closing():
-		return errClosing
-	case <-fd.csema:
-		fd.proc.Children().Add(1)
-		fd.csema <- signal{}
-		return nil
+func (fd *udtFD) Read(buf []byte) (int, error) {
+	n := int(C.udt_recv(fd.sock, slice2cbuf(buf), C.int(len(buf)), 0))
+	if C.int(n) == C.ERROR {
+		// got problems?
+		return 0, fd.udtIOError()
 	}
-}
-
-func (fd *udtFD) decref() {
-	fd.proc.Children().Done()
-}
-
-func (fd *udtFD) readLock() error {
-	// first acquire control sema to add ourselves as a child
-	if err := fd.incref(); err != nil {
-		return err
-	}
-
-	// second acquire read sema (one reader at a time)
-	select {
-	case <-fd.proc.Closing():
-		fd.decref() // didnt work out. undo
-		return errClosing
-	case <-fd.rsema:
-		return nil
-	}
-}
-
-func (fd *udtFD) readUnlock() {
-	fd.decref()
-	fd.rsema <- signal{}
-}
-
-func (fd *udtFD) writeLock() error {
-	select {
-	case <-fd.proc.Closing():
-		return errClosing
-	case <-fd.csema:
-		<-fd.wsema
-		fd.proc.Children().Add(1)
-		fd.csema <- signal{}
-		return nil
-	}
-}
-
-func (fd *udtFD) writeUnlock() {
-	fd.proc.Children().Done()
-	fd.wsema <- signal{}
-}
-
-func (fd *udtFD) Read(buf []byte) (readcnt int, err error) {
-	if err = fd.readLock(); err != nil {
-		return 0, err
-	}
-	defer fd.readUnlock()
-
-	readcnt = 0
-	for {
-		n := int(C.udt_recv(fd.sock, slice2cbuf(buf[readcnt:]), C.int(len(buf)-readcnt), 0))
-		if C.int(n) == C.ERROR {
-			// got problems?
-			if err = fd.udtIOError(); err != nil {
-				break
-			}
-			// nope, everything's fine. read again.
-			continue
-		}
-
-		if n > 0 {
-			readcnt += n
-		}
-		if err != nil { // bad things happened
-			break
-		}
-		if n == 0 {
-			err = io.EOF
-		}
-		break // return the data we have.
-	}
-	if err != nil && err != io.EOF {
-		err = &net.OpError{Op: "read", Net: fd.net, Addr: fd.laddr, Err: err}
-	}
-	return readcnt, err
+	return n, nil
 }
 
 func (fd *udtFD) Write(buf []byte) (writecnt int, err error) {
-	if err = fd.writeLock(); err != nil {
-		return 0, err
+	for len(buf) > writecnt {
+		n, err := fd.write(buf[writecnt:])
+		if err != nil {
+			return writecnt, err
+		}
+
+		writecnt += n
 	}
-	defer fd.writeUnlock()
+	return writecnt, nil
+}
 
-	writecnt = 0
-	for {
-		n := int(C.udt_send(fd.sock, slice2cbuf(buf[writecnt:]), C.int(len(buf)-writecnt), 0))
-
-		if C.int(n) == C.ERROR {
-			// UDT Error?
-			if err = fd.udtIOError(); err != nil {
-				break
-			}
-			// everything's fine, proceed
-		}
-
-		// update our running count
-		if n > 0 {
-			writecnt += n
-		}
-
-		if writecnt == len(buf) { // done!
-			break
-		}
-		if err != nil { // bad things happened
-			break
-		}
-		if n == 0 { // early eof?
-			err = io.ErrUnexpectedEOF
-			break
-		}
+func (fd *udtFD) write(buf []byte) (int, error) {
+	n := int(C.udt_send(fd.sock, slice2cbuf(buf), C.int(len(buf)), 0))
+	if C.int(n) == C.ERROR {
+		// UDT Error?
+		return 0, fd.udtIOError()
 	}
-	if err != nil {
-		err = &net.OpError{Op: "write", Net: fd.net, Addr: fd.raddr, Err: err}
-	}
-	return writecnt, err
+
+	return n, nil
 }
 
 type socketStatus C.enum_UDTSTATUS

--- a/udt/fd_rw.go
+++ b/udt/fd_rw.go
@@ -1,7 +1,6 @@
 package udt
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 )

--- a/udt/fd_test.go
+++ b/udt/fd_test.go
@@ -48,10 +48,6 @@ func TestUdtFDConstruct(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := fd.setDefaultOpts(); err != nil {
-		t.Fatal(err)
-	}
-
 	if fd.name() != "udt::1234->" {
 		t.Fatal("incorrect name:", fd.name())
 	}
@@ -115,8 +111,6 @@ func TestUdtFDListenOnly(t *testing.T) {
 	assert(t, nil == err, err)
 	fd, err := newFD(s, la, nil, "udt")
 	assert(t, nil == err, err)
-	err = fd.setDefaultOpts()
-	assert(t, nil == err, err)
 
 	if err := fd.listen(10); err == nil {
 		t.Fatal("should fail. must bind first")
@@ -148,10 +142,6 @@ func TestUdtFDAcceptAndConnect(t *testing.T) {
 	fdl, err := newFD(sl, al, nil, "udt")
 	assert(t, nil == err, err)
 	fdc, err := newFD(sc, nil, nil, "udt")
-	assert(t, nil == err, err)
-	err = fdl.setDefaultOpts()
-	assert(t, nil == err, err)
-	err = fdc.setDefaultOpts()
 	assert(t, nil == err, err)
 	err = fdl.bind()
 	assert(t, nil == err, err)
@@ -212,8 +202,6 @@ func TestUdtFDAcceptAndDialFD(t *testing.T) {
 	sl, err := socket(al.AF())
 	assert(t, nil == err, err)
 	fdl, err := newFD(sl, al, nil, "udt")
-	assert(t, nil == err, err)
-	err = fdl.setDefaultOpts()
 	assert(t, nil == err, err)
 	err = fdl.bind()
 	assert(t, nil == err, err)

--- a/udt/fd_test.go
+++ b/udt/fd_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"syscall"
 	"testing"
-	"time"
 )
 
 func TestSocketConstruct(t *testing.T) {
@@ -65,6 +65,8 @@ func TestUdtFDConstruct(t *testing.T) {
 	}
 }
 
+/* TODO: this test doesnt make any sense
+and feels like its just testing some goprocess stuff that we're not using anymore
 func TestUdtFDLocking(t *testing.T) {
 	a, err := ResolveUDTAddr("udt", ":1234")
 	assert(t, nil == err, err)
@@ -74,9 +76,6 @@ func TestUdtFDLocking(t *testing.T) {
 	assert(t, nil == err, err)
 	err = fd.setDefaultOpts()
 	assert(t, nil == err, err)
-
-	fd.proc.Children().Add(1)
-	done := make(semaphore, 1)
 
 	go func() {
 		if err := fd.Close(); err != nil {
@@ -106,9 +105,11 @@ func TestUdtFDLocking(t *testing.T) {
 		t.Fatal("sock should now be -1")
 	}
 }
+*/
 
 func TestUdtFDListenOnly(t *testing.T) {
-	la, err := ResolveUDTAddr("udt", ":1235")
+	addr := getTestAddr()
+	la, err := ResolveUDTAddr("udt", addr)
 	assert(t, nil == err, err)
 	s, err := socket(la.AF())
 	assert(t, nil == err, err)
@@ -137,7 +138,8 @@ func TestUdtFDListenOnly(t *testing.T) {
 }
 
 func TestUdtFDAcceptAndConnect(t *testing.T) {
-	al, err := ResolveUDTAddr("udt", "127.0.0.1:1234")
+	addr := getTestAddr()
+	al, err := ResolveUDTAddr("udt", addr)
 	assert(t, nil == err, err)
 	sl, err := socket(al.AF())
 	assert(t, nil == err, err)
@@ -204,7 +206,8 @@ func TestUdtFDAcceptAndConnect(t *testing.T) {
 }
 
 func TestUdtFDAcceptAndDialFD(t *testing.T) {
-	al, err := ResolveUDTAddr("udt", "127.0.0.1:1334")
+	addr := getTestAddr()
+	al, err := ResolveUDTAddr("udt", addr)
 	assert(t, nil == err, err)
 	sl, err := socket(al.AF())
 	assert(t, nil == err, err)
@@ -266,7 +269,8 @@ func TestUdtFDAcceptAndDialFD(t *testing.T) {
 }
 
 func TestUdtDialFDAndListenFD(t *testing.T) {
-	al, err := ResolveUDTAddr("udt", "127.0.0.1:1434")
+	addr := getTestAddr()
+	al, err := ResolveUDTAddr("udt", addr)
 	assert(t, nil == err, err)
 
 	cerrs := make(chan error, 10)
@@ -324,7 +328,8 @@ func TestUdtDialFDAndListenFD(t *testing.T) {
 }
 
 func TestUdtReadWrite(t *testing.T) {
-	al, err := ResolveUDTAddr("udt", "127.0.0.1:1534")
+	addr := getTestAddr()
+	al, err := ResolveUDTAddr("udt", addr)
 	assert(t, nil == err, err)
 
 	cerrs := make(chan error, 10)
@@ -333,8 +338,7 @@ func TestUdtReadWrite(t *testing.T) {
 		fdc, err := dialFD(nil, al)
 		assert(t, nil == err, err)
 
-		n, err := io.Copy(fdc, fdc)
-		fmt.Printf("echoed %d bytes\n", n)
+		_, err = io.Copy(fdc, fdc)
 		if err != nil {
 			cerrs <- err
 		}
@@ -357,19 +361,21 @@ func TestUdtReadWrite(t *testing.T) {
 	assert(t, fdl.listen(10) != nil, "should not be able to listen after closing")
 	assert(t, fdl.sock == -1, "sock should now be -1", fdl.sock)
 
-	fmt.Printf("closed and waiting\n")
 	// drain connector errs
 	for err := range cerrs {
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	fmt.Printf("done\n")
 }
 
 func assert(t *testing.T, cond bool, vals ...interface{}) {
 	if !cond {
-		t.Fatal(vals...)
+		_, file, line, _ := runtime.Caller(1)
+		prefix := fmt.Sprintf("%s:%d: ", file, line)
+
+		toprint := append([]interface{}{prefix}, vals...)
+		t.Fatal(toprint)
 	}
 }
 
@@ -379,39 +385,34 @@ func testSendToEcho(t *testing.T, conn net.Conn) {
 
 	buflen := 1024 * 12
 	buf := make([]byte, buflen)
-	for i := 0; i < 128; i++ {
 
+	for i := 0; i < 128; i++ {
 		for j := range buf {
 			buf[j] = byte('a' + (i % 26))
 		}
 
-		var err error
-		fmt.Printf("sending %d - %d", buflen, i)
-		for n, nn := 0, 0; n < buflen; n += nn {
-			nn, err = conn.Write(buf[n:])
-			fmt.Printf(".")
-			if err != nil {
-				t.Fatal(err)
-			}
+		nn, err := conn.Write(buf)
+		if err != nil {
+			t.Fatal(err)
 		}
-		fmt.Printf("\n")
+		if nn != buflen {
+			t.Fatal("wrote wrong number of bytes", nn, buflen)
+		}
 
-		fmt.Printf("receiving %d - %d ", buflen, i)
 		buf2 := make([]byte, buflen)
-		for n, nn := 0, 0; n < buflen; n += nn {
-			nn, err = conn.Read(buf2[n:])
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				t.Fatal(err)
-			}
+		n, err := io.ReadFull(conn, buf2)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		if n != buflen {
+			t.Fatal("read wrong number of bytes somehow")
 		}
 
 		if !bytes.Equal(buf, buf2) {
 			t.Fatal("bufs differ:\n\n%s\n\n%s", string(buf), string(buf2))
 		}
-
-		fmt.Printf("ok\n")
 	}
 
 	// the meat of the test is here ^^^

--- a/udt/udt_bsd.go
+++ b/udt/udt_bsd.go
@@ -5,5 +5,5 @@ package udt
 import "syscall"
 
 func maxRcvBufSize() (uint32, error) {
-  return syscall.SysctlUint32("kern.ipc.maxsockbuf")
+	return syscall.SysctlUint32("kern.ipc.maxsockbuf")
 }

--- a/udt/udt_test.go
+++ b/udt/udt_test.go
@@ -3,6 +3,7 @@ package udt
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -25,7 +26,7 @@ func TestStressOps(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < numcons; i++ {
 		wg.Add(1)
-		go func() {
+		go func(nc int) {
 			defer wg.Done()
 			con, err := Dial("udt", addr)
 			if err != nil {
@@ -42,7 +43,9 @@ func TestStressOps(t *testing.T) {
 					t.Fatal("wrote wrong amount")
 				}
 			}
-		}()
+
+			fmt.Printf("%d/%d done sending\n", nc, numcons)
+		}(i)
 	}
 
 	var rwg sync.WaitGroup
@@ -53,7 +56,7 @@ func TestStressOps(t *testing.T) {
 		}
 
 		rwg.Add(1)
-		go func(c net.Conn) {
+		go func(nc int, c net.Conn) {
 			defer rwg.Done()
 			defer c.Close()
 			buf := make([]byte, 1024)
@@ -67,7 +70,9 @@ func TestStressOps(t *testing.T) {
 					t.Fatal("read wrong data")
 				}
 			}
-		}(c)
+
+			fmt.Printf("%d/%d done receiving\n", nc, numcons)
+		}(i, c)
 	}
 
 	wg.Wait()

--- a/udt/udt_test.go
+++ b/udt/udt_test.go
@@ -1,8 +1,75 @@
 package udt
 
 import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"net"
+	"sync"
 	"testing"
 )
 
-func TestStuff(t *testing.T) {
+func TestStressOps(t *testing.T) {
+	addr := getTestAddr()
+	l, err := Listen("udt", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcbuf := make([]byte, 50000)
+	rand.Read(srcbuf)
+
+	numcons := 200
+	numloops := 5000
+
+	var wg sync.WaitGroup
+	for i := 0; i < numcons; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			con, err := Dial("udt", addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer con.Close()
+
+			for i := 0; i < numloops; i++ {
+				n, err := con.Write(srcbuf[i : i+1024])
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n != 1024 {
+					t.Fatal("wrote wrong amount")
+				}
+			}
+		}()
+	}
+
+	var rwg sync.WaitGroup
+	for i := 0; i < numcons; i++ {
+		c, err := l.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rwg.Add(1)
+		go func(c net.Conn) {
+			defer rwg.Done()
+			defer c.Close()
+			buf := make([]byte, 1024)
+			for i := 0; i < numloops; i++ {
+				_, err := io.ReadFull(c, buf)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buf, srcbuf[i:i+1024]) {
+					t.Fatal("read wrong data")
+				}
+			}
+		}(c)
+	}
+
+	wg.Wait()
+	rwg.Wait()
 }

--- a/udt/udt_windows.go
+++ b/udt/udt_windows.go
@@ -3,5 +3,5 @@ package udt
 import "errors"
 
 func maxRcvBufSize() (uint32, error) {
-  return 0, errors.New("no idea how to check this")
+	return 0, errors.New("no idea how to check this")
 }


### PR DESCRIPTION
This is a moderate rewrite of the bindings to clean up some race conditions, and remove unnecessary async stuff. It also has roughly double the throughput as before.